### PR TITLE
bugfix: size_factors_init two times expand dims

### DIFF
--- a/batchglm/models/base_glm/input.py
+++ b/batchglm/models/base_glm/input.py
@@ -197,4 +197,4 @@ class InputDataGLM(InputDataBase):
         return self.design_scale[idx, :]
 
     def fetch_size_factors(self, idx):
-        return self.size_factors[idx]
+        return self.size_factors[idx, :]

--- a/batchglm/train/tf1/glm_beta/estimator.py
+++ b/batchglm/train/tf1/glm_beta/estimator.py
@@ -169,8 +169,6 @@ class Estimator(TFEstimatorGLM, ProcessModel):
         $$
         """
 
-        size_factors_init = input_data.size_factors
-
         if init_model is None:
             groupwise_means = None
             init_a_str = None
@@ -185,7 +183,7 @@ class Estimator(TFEstimatorGLM, ProcessModel):
                         x=input_data.x,
                         design_loc=input_data.design_loc,
                         constraints_loc=input_data.constraints_loc,
-                        size_factors=size_factors_init,
+                        size_factors=input_data.size_factors,
                         link_fn=lambda mean: np.log(
                             1/(1/self.np_clip_param(mean, "mean")-1)
                         )
@@ -221,7 +219,7 @@ class Estimator(TFEstimatorGLM, ProcessModel):
                         x=input_data.x,
                         design_scale=input_data.design_scale[:, [0]],
                         constraints=input_data.constraints_scale[[0], :][:, [0]],
-                        size_factors=size_factors_init,
+                        size_factors=input_data.size_factors,
                         groupwise_means=None,
                         link_fn=lambda samplesize: np.log(self.np_clip_param(samplesize, "samplesize"))
                     )
@@ -248,7 +246,7 @@ class Estimator(TFEstimatorGLM, ProcessModel):
                         x=input_data.x,
                         design_scale=input_data.design_scale,
                         constraints=input_data.constraints_scale,
-                        size_factors=size_factors_init,
+                        size_factors=input_data.size_factors,
                         groupwise_means=groupwise_means,
                         link_fn=lambda samplesize: np.log(self.np_clip_param(samplesize, "samplesize"))
                     )
@@ -291,4 +289,3 @@ class Estimator(TFEstimatorGLM, ProcessModel):
                 logging.getLogger("batchglm").debug("Using initialization based on input model for dispersion")
 
         return init_a, init_b
-

--- a/batchglm/train/tf1/glm_nb/estimator.py
+++ b/batchglm/train/tf1/glm_nb/estimator.py
@@ -176,14 +176,6 @@ class Estimator(TFEstimatorGLM, ProcessModel):
         $$
         """
 
-        size_factors_init = input_data.size_factors
-        if size_factors_init is not None:
-            size_factors_init = np.expand_dims(size_factors_init, axis=1)
-            size_factors_init = np.broadcast_to(
-                array=size_factors_init,
-                shape=[input_data.num_observations, input_data.num_features]
-            )
-
         if init_model is None:
             groupwise_means = None
             init_a_str = None
@@ -198,7 +190,7 @@ class Estimator(TFEstimatorGLM, ProcessModel):
                         x=input_data.x,
                         design_loc=input_data.design_loc,
                         constraints_loc=input_data.constraints_loc,
-                        size_factors=size_factors_init,
+                        size_factors=input_data.size_factors,
                         link_fn=lambda mu: np.log(self.np_clip_param(mu, "mu"))
                     )
 
@@ -239,7 +231,7 @@ class Estimator(TFEstimatorGLM, ProcessModel):
                         x=input_data.x,
                         design_scale=input_data.design_scale[:, [0]],
                         constraints=input_data.constraints_scale[[0], :][:, [0]],
-                        size_factors=size_factors_init,
+                        size_factors=input_data.size_factors,
                         groupwise_means=None,
                         link_fn=lambda r: np.log(self.np_clip_param(r, "r"))
                     )
@@ -267,7 +259,7 @@ class Estimator(TFEstimatorGLM, ProcessModel):
                         x=input_data.x,
                         design_scale=input_data.design_scale,
                         constraints=input_data.constraints_scale,
-                        size_factors=size_factors_init,
+                        size_factors=input_data.size_factors,
                         groupwise_means=groupwise_means,
                         link_fn=lambda r: np.log(self.np_clip_param(r, "r"))
                     )

--- a/batchglm/train/tf1/glm_norm/estimator.py
+++ b/batchglm/train/tf1/glm_norm/estimator.py
@@ -172,14 +172,6 @@ class Estimator(TFEstimatorGLM, ProcessModel):
         $$
         """
 
-        size_factors_init = input_data.size_factors
-        if size_factors_init is not None:
-            size_factors_init = np.expand_dims(size_factors_init, axis=1)
-            size_factors_init = np.broadcast_to(
-                array=size_factors_init,
-                shape=[input_data.num_observations, input_data.num_features]
-            )
-
         sf_given = False
         if input_data.size_factors is not None:
             if np.any(np.abs(input_data.size_factors - 1.) > 1e-8):
@@ -268,7 +260,7 @@ class Estimator(TFEstimatorGLM, ProcessModel):
                         x=input_data.x,
                         design_scale=input_data.design_scale,
                         constraints=input_data.constraints_scale,
-                        size_factors=size_factors_init,
+                        size_factors=input_data.size_factors,
                         groupwise_means=groupwise_means,
                         link_fn=lambda sd: np.log(self.np_clip_param(sd, "sd"))
                     )
@@ -282,7 +274,7 @@ class Estimator(TFEstimatorGLM, ProcessModel):
                         x=input_data.x,
                         design_scale=input_data.design_scale[:, [0]],
                         constraints=input_data.constraints_scale[[0], :][:, [0]],
-                        size_factors=size_factors_init,
+                        size_factors=input_data.size_factors,
                         groupwise_means=None,
                         link_fn=lambda sd: np.log(self.np_clip_param(sd, "sd"))
                     )
@@ -331,4 +323,3 @@ class Estimator(TFEstimatorGLM, ProcessModel):
                 logger.debug("Using initialization based on input model for dispersion")
 
         return init_a, init_b
-


### PR DESCRIPTION
Bug: 
@davidsebfischer: this commit https://github.com/theislab/batchglm/commit/01d30c72a4710f9b01754f6843b11e99fb892a85 is a breaking change.

You included the dimension expansion of size_factors into `batchglm/models/base_glm/input.py` where it is now checked in `InputDataGlm.__init__`. 
However, this is breaking change because this expansion is conducted in the `Estimator.init_par` function of each noise model in the train subfolder. 
You deleted it from the numpy backend, but not from the tf1 backend. 

This pull request includes the necessary changes in the estimators of the tf1 backend for nb, beta and norm noise models. 
The changes for the tf2 backend are dealt with using the tf2 branch. 