### PR TITLE
force and check param_names if necessary

### DIFF
--- a/batchglm/unit_test/test_dmat.py
+++ b/batchglm/unit_test/test_dmat.py
@@ -1,0 +1,81 @@
+import unittest
+import numpy as np
+import dask
+import pandas as pd
+import patsy
+from typing import Union, List
+from batchglm.models.base_glm.utils import parse_design
+
+
+def check_np_dask(dmat: Union[np.ndarray, dask.array.core.Array], params: List[str]) -> bool:
+    parse_design(design_matrix=dmat, param_names=params)
+    try:  # must produce ValueError
+        parse_design(design_matrix=dmat, param_names=None)
+        return False
+    except ValueError as ve:
+        if not str(ve) == 'Provide names when passing design_matrix as np.ndarray or dask.array.core.Array!':
+            raise
+    try:  # must result in AssertionError
+        parse_design(design_matrix=dmat, param_names=params[:-1])
+        return False
+    except AssertionError as ae:
+        if not (str(ae) == "Length of provided param_names is not equal to number of coefficients in design_matrix."
+            or str(ae).startswith("Datatype for design_matrix not understood")):
+            raise
+    return True
+
+def check_pd_patsy(dmat: Union[pd.DataFrame, patsy.design_info.DesignMatrix], params: List[str]) -> bool:
+    _, ret_params = parse_design(design_matrix=dmat, param_names=None)
+    if ret_params != params:
+        return False
+
+    # generate new coefs to test ignoring passed params
+    new_coef_list = ["a", "b", "c"]
+
+    # param_names should be ignored
+    _, ret_params = parse_design(design_matrix=dmat, param_names=new_coef_list)
+    if params != ret_params:
+        return False
+    # param_names should be ignored
+    _, ret_params = parse_design(design_matrix=dmat, param_names=new_coef_list[:-1])
+    if params != ret_params:
+        return False
+    return True
+
+
+class TestParseDesign(unittest.TestCase):
+    """
+    Test various input data types for parsing of design and constraint matrices.
+    The method "parse_design" in batchglm.models.base_glm.utils must return Tuple[np.ndarray, List[str]].
+    It must fail if no param_names are passed or the length of param_names is not equal to the length of params.
+    """
+    def test_parse_design(self) -> bool:
+        # create artificial data
+        obs, coef = (500, 3)
+        dmat = np.zeros(shape=(obs, coef))
+        coef_list = ["Intercept", "coef_0", "coef_1"]
+
+        # check np
+        if not(check_np_dask(dmat=dmat, params=coef_list)):
+            return False
+        # check dask
+        if not(check_np_dask(dmat=dask.array.from_array(dmat, chunks=(1000, 1000)), params=coef_list)):
+            return False
+        # check pd
+        pd_coef = pd.DataFrame(dmat, columns=coef_list)
+        if not(check_pd_patsy(dmat=pd_coef, params=coef_list)):
+            return False
+        # check patsy
+        if not(check_pd_patsy(dmat=patsy.dmatrix("~1 + coef_0 + coef_1", pd_coef), params=coef_list)):
+            return False
+        # check wrong datatype
+        try:
+            parse_design(design_matrix=list(dmat), param_names=coef_list)
+        except AssertionError as ae:
+            if not str(ae).startswith("Datatype for design_matrix not understood"):
+                raise
+        return True
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
these are fixes that solve issue #102 .
All changes are made in `batchglm/models/base_glm/utils.py` in the function `parse_design`.
@davidsebfischer 
You still need to check the docstring, because I am not quite familiar with the correct syntax.
Here is the diff:
```diff
@@ -22,28 +22,33 @@ def parse_design(
     Parser for design matrices.
 
     :param design_matrix: Design matrix.
-    :param param_names:
+    :param param_names: Optional column names for design_matrix (names of individual coefficients).
     :return: Tuple containing the design matrix and the parameter names.
+    :raise ValueError: if the type of design_matrix is not understood.
+    :raise ValueError: if param_names is None when type of design_matrix is numpy.ndarray or dask.array.core.Array
+    :raise AssertionError: if length of provided param_names is not equal to number of coefficients in design_matrix
     """
+
+    params = None
     if isinstance(design_matrix, patsy.design_info.DesignMatrix):
         dmat = np.asarray(design_matrix)
         params = design_matrix.design_info.column_names
     elif isinstance(design_matrix, pd.DataFrame):
         dmat = np.asarray(design_matrix)
         params = design_matrix.columns
-    elif isinstance(design_matrix, np.ndarray):
-        dmat = design_matrix
-        params = None
     elif isinstance(design_matrix, dask.array.core.Array):
         dmat = design_matrix.compute()
-        params = None
+        params = param_names
+    elif isinstance(design_matrix, np.ndarray):
+        dmat = design_matrix
+        params = param_names
     else:
         raise ValueError("type %s not recognized" % type(design_matrix))
-
-    if param_names is not None:
-        if params is None:
-            assert len(param_names) == dmat.shape[1]
-            params = param_names
+    if params is None:
+        raise ValueError(
+            'Provide names when passing design_matrix as np.ndarray or dask.array.core.Array!')
+    assert len(params) == dmat.shape[1], "Length of provided param_names is not equal to " \
+        "number of coefficients in design_matrix."
 
     return dmat, params

```

I also changed sth. in `parse_constraints` in the same file.
Even when passing `constraint_par_names`, the function still calculated `constraint_params` from the `design_par_names` before assigning `constraint_params = constraint_par_names` anyways, if they have the correct length!
With the change applied, this unnecessary calculation doesn't happen any longer.
@davidsebfischer Please have a look at the diff to determine whether this could be a problem: 
```diff
@@ -70,15 +75,15 @@ def parse_constraints(
             constraints = constraints.compute()
         # Cannot use all parameter names if constraint matrix is not identity: Make up new ones.
         # Use variable names that can be mapped (unconstrained).
-        constraint_params = ["var_"+str(i) if np.sum(constraints[:, i] != 0) > 1
-                             else dmat_par_names[np.where(constraints[:, i] != 0)[0][0]]
-                             for i in range(constraints.shape[1])]
+        if constraint_par_names is not None:
+            assert len(constraint_params) == len(constraint_par_names)
+            constraint_params = constraint_par_names
+        else:
+            constraint_params = ["var_"+str(i) if np.sum(constraints[:, i] != 0) > 1
+                                 else dmat_par_names[np.where(constraints[:, i] != 0)[0][0]]
+                                 for i in range(constraints.shape[1])]
         assert constraints.shape[0] == dmat.shape[1], "constraint dimension mismatch"
 
-    if constraint_par_names is not None:
-        assert len(constraint_params) == len(constraint_par_names)
-        constraint_params = constraint_par_names
-
     return constraints, constraint_params

```