### PR TITLE
add missing definition of coef_names when dmat is provided directly

### DIFF
--- a/batchglm/data.py
+++ b/batchglm/data.py
@@ -235,12 +235,16 @@ def constraint_system_from_star(
         if isinstance(dmat, pd.DataFrame):
             coef_names = dmat.columns
             dmat = dmat.values
+        else:
+            coef_names = dmat.design_info.column_names
     elif constraints is None:
         cmat = None
         term_names = None
         if isinstance(dmat, pd.DataFrame):
             coef_names = dmat.columns
             dmat = dmat.values
+        else:
+            coef_names = dmat.design_info.column_names
     else:
         raise ValueError("constraint format %s not recognized" % type(constraints))
 


### PR DESCRIPTION
fixes the following error if dmat is provided directly and no constraints are defined:

```pytb
---------------------------------------------------------------------------
UnboundLocalError                         Traceback (most recent call last)
<ipython-input-57-7a3c9b6e66af> in <module>
      5         coef_totest = ["C(treatment_chronic, levels=l_chr)[T.Chr]"],
      6         batch_size=(1e9,512),
----> 7         train_args={"nproc": 40}
      8     )

~/.local/lib/python3.7/site-packages/diffxpy/testing/tests.py in wald(data, factor_loc_totest, coef_to_test, formula_loc, formula_scale, as_numeric, init_a, init_b, gene_names, sample_description, dmat_loc, dmat_scale, constraints_loc, constraints_scale, noise_model, size_factors, batch_size, backend, train_args, training_strategy, quick_scale, dtype, **kwargs)
    651         as_numeric=as_numeric,
    652         constraints=constraints_loc,
--> 653         return_type="patsy"
    654     )
    655     design_scale, design_scale_names, constraints_scale, term_names_scale = constraint_system_from_star(

~/.local/lib/python3.7/site-packages/diffxpy/testing/utils.py in constraint_system_from_star(dmat, sample_description, formula, as_numeric, constraints, return_type)
    270         as_categorical=as_categorical,
    271         constraints=constraints,
--> 272         return_type=return_type
    273     )
    274 

~/.local/lib/python3.7/site-packages/batchglm/data.py in constraint_system_from_star(dmat, sample_description, formula, as_categorical, constraints, return_type)
    259             )
    260 
--> 261     return dmat, coef_names, cmat, term_names
    262 
    263 

UnboundLocalError: local variable 'coef_names' referenced before assignment
```