### PR TITLE
fix missing param_names / clean imports:

### DIFF
--- a/batchglm/api/models/numpy/glm_nb.py
+++ b/batchglm/api/models/numpy/glm_nb.py
@@ -1,2 +1,2 @@
-from batchglm.models.glm_nb import InputDataGLM, Model, Simulator
+from batchglm.models.glm_nb import Model, Simulator
 from batchglm.train.numpy.glm_nb import Estimator

--- a/batchglm/models/base/simulator.py
+++ b/batchglm/models/base/simulator.py
@@ -42,12 +42,12 @@ class _SimulatorBase(metaclass=abc.ABCMeta):
         self.input_data = None
         self.model = model
 
-    def generate(self):
+    def generate(self, sparse: bool = False):
         """
         First generates the parameter set, then observations random data using these parameters
         """
         self.generate_params()
-        self.generate_data()
+        self.generate_data(sparse=sparse)
 
     @abc.abstractmethod
     def generate_data(self, *args, **kwargs):

--- a/batchglm/models/base_glm/simulator.py
+++ b/batchglm/models/base_glm/simulator.py
@@ -6,6 +6,7 @@ import patsy
 from typing import Union, Tuple
 
 from .model import _ModelGLM
+from .input import InputDataGLM
 from .external import _SimulatorBase
 
 
@@ -143,6 +144,17 @@ class _SimulatorGLM(_SimulatorBase, metaclass=abc.ABCMeta):
         self.sim_b_var = np.concatenate([
             rand_fn_scale((self.sim_design_scale.shape[1], self.nfeatures))
         ], axis=0)
+
+    def assemble_input_data(self, data_matrix: np.ndarray, sparse: bool):
+        if sparse:
+            data_matrix = scipy.sparse.csr_matrix(data_matrix)
+        self.input_data = InputDataGLM(
+            data=data_matrix,
+            design_loc=self.sim_design_loc,
+            design_scale=self.sim_design_scale,
+            design_loc_names=None,
+            design_scale_names=None
+        )
 
     @property
     def size_factors(self):

--- a/batchglm/models/glm_beta/__init__.py
+++ b/batchglm/models/glm_beta/__init__.py
@@ -1,3 +1,3 @@
 from .model import Model
-from .external import InputDataGLM, _EstimatorGLM
+from .external import _EstimatorGLM
 from .simulator import Simulator

--- a/batchglm/models/glm_beta/external.py
+++ b/batchglm/models/glm_beta/external.py
@@ -1,5 +1,4 @@
 from batchglm.models.base_glm import _EstimatorGLM
-from batchglm.models.base_glm import InputDataGLM
 from batchglm.models.base_glm import _ModelGLM
 from batchglm.models.base_glm import _SimulatorGLM
 from batchglm.models.base_glm import closedform_glm_mean, closedform_glm_scale

--- a/batchglm/models/glm_beta/simulator.py
+++ b/batchglm/models/glm_beta/simulator.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from .model import Model
-from .external import InputDataGLM, _SimulatorGLM
+from .external import _SimulatorGLM
 from .external import pkg_constants
 
 
@@ -74,7 +74,7 @@ class Simulator(_SimulatorGLM, Model):
             rand_fn_scale=rand_fn_scale,
         )
 
-    def generate_data(self):
+    def generate_data(self, sparse: bool = False):
         """
         Sample random data based on beta distribution and parameters.
         """
@@ -83,10 +83,4 @@ class Simulator(_SimulatorGLM, Model):
             b=self.q,
             size=None
         )
-        self.input_data = InputDataGLM(
-            data=data_matrix,
-            design_loc=self.sim_design_loc,
-            design_scale=self.sim_design_scale,
-            design_loc_names=None,
-            design_scale_names=None
-        )
+        self.assemble_input_data(data_matrix, sparse)

--- a/batchglm/models/glm_nb/__init__.py
+++ b/batchglm/models/glm_nb/__init__.py
@@ -1,3 +1,3 @@
 from .model import Model
-from .external import InputDataGLM, _EstimatorGLM
+from .external import _EstimatorGLM
 from .simulator import Simulator

--- a/batchglm/models/glm_nb/external.py
+++ b/batchglm/models/glm_nb/external.py
@@ -1,5 +1,4 @@
 from batchglm.models.base_glm import _EstimatorGLM
-from batchglm.models.base_glm import InputDataGLM
 from batchglm.models.base_glm import _ModelGLM
 from batchglm.models.base_glm import _SimulatorGLM
 from batchglm.models.base_glm import closedform_glm_mean, closedform_glm_scale

--- a/batchglm/models/glm_nb/simulator.py
+++ b/batchglm/models/glm_nb/simulator.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from .model import Model
-from .external import _SimulatorGLM, InputDataGLM
+from .external import _SimulatorGLM
 from .external import pkg_constants
 
 
@@ -42,7 +42,7 @@ class Simulator(_SimulatorGLM, Model):
             rand_fn_scale=rand_fn_scale,
         )
 
-    def generate_data(self):
+    def generate_data(self, sparse: bool = False):
         """
         Sample random data based on negative binomial distribution and parameters.
         """
@@ -51,13 +51,7 @@ class Simulator(_SimulatorGLM, Model):
             p=1 - self.mu / (self.phi + self.mu),
             size=None
         )
-        self.input_data = InputDataGLM(
-            data=data_matrix,
-            design_loc=self.sim_design_loc,
-            design_scale=self.sim_design_scale,
-            design_loc_names=None,
-            design_scale_names=None
-        )
+        self.assemble_input_data(data_matrix, sparse)
 
     def param_bounds(
             self,

--- a/batchglm/models/glm_norm/__init__.py
+++ b/batchglm/models/glm_norm/__init__.py
@@ -1,3 +1,3 @@
 from .model import Model
-from .external import InputDataGLM, _EstimatorGLM
+from .external import _EstimatorGLM
 from .simulator import Simulator

--- a/batchglm/models/glm_norm/external.py
+++ b/batchglm/models/glm_norm/external.py
@@ -1,5 +1,4 @@
 from batchglm.models.base_glm import _EstimatorGLM
-from batchglm.models.base_glm import InputDataGLM
 from batchglm.models.base_glm import _ModelGLM
 from batchglm.models.base_glm import _SimulatorGLM
 from batchglm.models.base_glm import closedform_glm_mean, closedform_glm_scale

--- a/batchglm/models/glm_norm/simulator.py
+++ b/batchglm/models/glm_norm/simulator.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from .model import Model
-from .external import InputDataGLM, _SimulatorGLM
+from .external import _SimulatorGLM
 from .external import pkg_constants
 
 
@@ -70,7 +70,7 @@ class Simulator(_SimulatorGLM, Model):
             rand_fn_scale=rand_fn_scale,
         )
 
-    def generate_data(self):
+    def generate_data(self, sparse: bool = False):
         """
         Sample random data based on normal distribution and parameters.
         """
@@ -79,10 +79,4 @@ class Simulator(_SimulatorGLM, Model):
             scale=self.sd,
             size=None
         )
-        self.input_data = InputDataGLM(
-            data=data_matrix,
-            design_loc=self.sim_design_loc,
-            design_scale=self.sim_design_scale,
-            design_loc_names=None,
-            design_scale_names=None
-        )
+        self.assemble_input_data(data_matrix, sparse)

--- a/batchglm/train/numpy/glm_nb/external.py
+++ b/batchglm/train/numpy/glm_nb/external.py
@@ -1,6 +1,7 @@
 import batchglm.data as data_utils
 
-from batchglm.models.glm_nb import _EstimatorGLM, InputDataGLM, Model
+from batchglm.models.glm_nb import _EstimatorGLM, Model
+from batchglm.models.base_glm import InputDataGLM
 from batchglm.models.base_glm.utils import closedform_glm_mean, closedform_glm_scale
 from batchglm.models.glm_nb.utils import init_par
 

--- a/batchglm/unit_test/test_acc_glm_all_numpy.py
+++ b/batchglm/unit_test/test_acc_glm_all_numpy.py
@@ -4,7 +4,7 @@ import scipy.sparse
 import unittest
 
 import batchglm.api as glm
-
+from batchglm.models.base_glm import InputDataGLM
 glm.setup_logging(verbosity="WARNING", stream="STDOUT")
 logger = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ class _TestAccuracyGlmAllEstim:
             raise ValueError("noise_model is None")
         else:
             if noise_model == "nb":
-                from batchglm.api.models.numpy.glm_nb import Estimator, InputDataGLM
+                from batchglm.api.models.numpy.glm_nb import Estimator
             else:
                 raise ValueError("noise_model not recognized")
 

--- a/batchglm/unit_test/test_data_types_glm_all.py
+++ b/batchglm/unit_test/test_data_types_glm_all.py
@@ -9,6 +9,7 @@ import unittest
 import scipy.sparse
 
 import batchglm.api as glm
+from batchglm.models.base_glm import InputDataGLM
 from batchglm.unit_test.test_graph_glm_all import _TestGraphGlmAll
 
 glm.setup_logging(verbosity="WARNING", stream="STDOUT")
@@ -39,9 +40,7 @@ class _TestDataTypesGlmAll(_TestGraphGlmAll):
         if self.noise_model is None:
             raise ValueError("noise_model is None")
         else:
-            if self.noise_model == "nb":
-                from batchglm.api.models.numpy.glm_nb import InputDataGLM
-            else:
+            if not self.noise_model == "nb":
                 raise ValueError("noise_model not recognized")
 
         return InputDataGLM(

--- a/batchglm/unit_test/test_extreme_values_glm_all.py
+++ b/batchglm/unit_test/test_extreme_values_glm_all.py
@@ -3,6 +3,7 @@ import numpy as np
 import unittest
 
 import batchglm.api as glm
+from batchglm.models.base_glm import InputDataGLM
 from batchglm.unit_test.test_graph_glm_all import _TestGraphGlmAll
 
 glm.setup_logging(verbosity="WARNING", stream="STDOUT")
@@ -19,7 +20,7 @@ class _TestAccuracyXtremeAll(_TestGraphGlmAll):
             raise ValueError("noise_model is None")
         else:
             if self.noise_model == "nb":
-                from batchglm.api.models.numpy.glm_nb import Estimator, InputDataGLM
+                from batchglm.api.models.numpy.glm_nb import Estimator
             else:
                 raise ValueError("noise_model not recognized")
 
@@ -29,7 +30,9 @@ class _TestAccuracyXtremeAll(_TestGraphGlmAll):
         input_data = InputDataGLM(
             data=x,
             design_loc=self.sim1.input_data.design_loc,
-            design_scale=self.sim1.input_data.design_scale
+            design_scale=self.sim1.input_data.design_scale,
+            design_loc_names=self.sim1.input_data.design_loc_names,
+            design_scale_names=self.sim1.input_data.design_scale_names
         )
         self.sim1.input_data = input_data
 

--- a/batchglm/unit_test/test_graph_glm_all.py
+++ b/batchglm/unit_test/test_graph_glm_all.py
@@ -3,6 +3,7 @@ import logging
 import scipy.sparse
 
 import batchglm.api as glm
+from batchglm.models.base_glm import InputDataGLM
 
 glm.setup_logging(verbosity="WARNING", stream="STDOUT")
 logger = logging.getLogger(__name__)
@@ -23,7 +24,7 @@ class _TestGraphGlmAllEstim:
             raise ValueError("noise_model is None")
         else:
             if noise_model == "nb":
-                from batchglm.api.models.numpy.glm_nb import Estimator, InputDataGLM
+                from batchglm.api.models.numpy.glm_nb import Estimator
             else:
                 raise ValueError("noise_model not recognized")
 
@@ -39,13 +40,17 @@ class _TestGraphGlmAllEstim:
             input_data = InputDataGLM(
                 data=scipy.sparse.csr_matrix(simulator.input_data.x),
                 design_loc=simulator.input_data.design_loc,
-                design_scale=simulator.input_data.design_scale
+                design_scale=simulator.input_data.design_scale,
+                design_loc_names=simulator.input_data.design_loc_names,
+                design_scale_names=simulator.input_data.design_scale_names
             )
         else:
             input_data = InputDataGLM(
                 data=simulator.input_data.x,
                 design_loc=simulator.input_data.design_loc,
-                design_scale=simulator.input_data.design_scale
+                design_scale=simulator.input_data.design_scale,
+                design_loc_names=simulator.input_data.design_loc_names,
+                design_scale_names=simulator.input_data.design_scale_names
             )
 
         estimator = Estimator(


### PR DESCRIPTION
- fixed loc/scale param names missing in unittests after merging #103
- clean import structure of InputDataGLM
- move generation of InputDataGLM in base_glm simulator
- support generating sparse data directly in simulator

This branch cleans the import structure of InputDataGLM: This is a class that is only defined in batchglm.models.base_glm and it isn't inherited in the noise model specific submodules. Yet we have always imported this from the specific submodule and imported it from .external.py which was really quite unnecessary and made submodules unnecessarily convoluted. 

It also fixes the unit tests that aren't working after merging of #103.
Additionally, we need to recreate InputDaaGLM instances in order to get a sparse and dense version from the existing input_data attribute in the simulator. I find this unintuitive and added a sparse argument to the generate function in the simulator that supports sparse directly.