### PR TITLE
`a` -> `location` + `b` -> `scale` + formatting

### DIFF
--- a/batchglm/models/base/estimator.py
+++ b/batchglm/models/base/estimator.py
@@ -25,6 +25,7 @@ class _EstimatorBase(metaclass=abc.ABCMeta):
     """
     Estimator base class
     """
+
     model: _ModelBase
     _loss: np.ndarray
     _jacobian: np.ndarray
@@ -59,39 +60,39 @@ class _EstimatorBase(metaclass=abc.ABCMeta):
 
     @property
     def jacobian(self) -> np.ndarray:
-        """"Current Jacobian of the log likelihood"""
+        """Current Jacobian of the log likelihood"""
         return self._jacobian
 
     @property
     def hessian(self) -> np.ndarray:
-        """"Current Hessian of the log likelihood"""
+        """Current Hessian of the log likelihood"""
         return self._hessian
 
     @property
     def fisher_inv(self) -> np.ndarray:
-        """"Current Fisher Inverse Matrix"""
+        """Current Fisher Inverse Matrix"""
         return self._fisher_inv
 
     @property
     def x(self) -> Union[np.ndarray, dask.array.core.Array]:
-        """"Data Matrix"""
+        """Data Matrix"""
         return self.input_data.x
 
     @property
-    def a_var(self):
-        """"Fit location parameter"""
-        if isinstance(self.model.a_var, dask.array.core.Array):
-            return self.model.a_var.compute()
+    def theta_location(self):
+        """Fit location parameter"""
+        if isinstance(self.model.theta_location, dask.array.core.Array):
+            return self.model.theta_location.compute()
         else:
-            return self.model.a_var
+            return self.model.theta_location
 
     @property
-    def b_var(self) -> np.ndarray:
+    def theta_scale(self) -> np.ndarray:
         """Fit scale parameter"""
-        if isinstance(self.model.b_var, dask.array.core.Array):
-            return self.model.b_var.compute()
+        if isinstance(self.model.theta_scale, dask.array.core.Array):
+            return self.model.theta_scale.compute()
         else:
-            return self.model.b_var
+            return self.model.theta_scale
 
     @abc.abstractmethod
     def initialize(self, **kwargs):

--- a/batchglm/models/base/model.py
+++ b/batchglm/models/base/model.py
@@ -9,8 +9,6 @@ try:
 except ImportError:
     anndata = None
 
-from .input import InputDataBase
-
 logger = logging.getLogger(__name__)
 
 

--- a/batchglm/models/base_glm/estimator.py
+++ b/batchglm/models/base_glm/estimator.py
@@ -25,6 +25,7 @@ class _EstimatorGLM(_EstimatorBase, metaclass=abc.ABCMeta):
     input_data : InputDataGLM
         Data to be fit on
     """
+
     model: _ModelGLM
     input_data: InputDataGLM
 
@@ -37,7 +38,7 @@ class _EstimatorGLM(_EstimatorBase, metaclass=abc.ABCMeta):
         """
         _EstimatorBase.__init__(self=self, model=model, input_data=input_data)
 
-    def plot_coef_a_vs_ref(
+    def plot_coef_location_vs_ref(
         self,
         true_values: np.ndarray,
         size=1,
@@ -64,15 +65,15 @@ class _EstimatorGLM(_EstimatorBase, metaclass=abc.ABCMeta):
         :return: Matplotlib axis objects.
         """
         assert len(true_values.shape) == len(
-            self.model.a_var.shape
-        ), "true_values must have same dimensions as self.a_var"
+            self.model.theta_location.shape
+        ), "true_values must have same dimensions as self.theta_location"
         assert np.all(
-            true_values.shape == self.model.a_var.shape
-        ), "true_values must have same dimensions as self.a_var"
+            true_values.shape == self.model.theta_location.shape
+        ), "true_values must have same dimensions as self.theta_location"
 
         return self._plot_coef_vs_ref(
             true_values=true_values,
-            estim_values=self.model.a_var,
+            estim_values=self.model.theta_location,
             size=size,
             log=log,
             save=save,
@@ -84,7 +85,7 @@ class _EstimatorGLM(_EstimatorBase, metaclass=abc.ABCMeta):
             return_axs=return_axs,
         )
 
-    def plot_coef_b_vs_ref(
+    def plot_coef_scale_vs_ref(
         self,
         true_values: np.ndarray,
         size=1,
@@ -111,15 +112,15 @@ class _EstimatorGLM(_EstimatorBase, metaclass=abc.ABCMeta):
         :return: Matplotlib axis objects.
         """
         assert len(true_values.shape) == len(
-            self.model.b_var.shape
-        ), "true_values must have same dimensions as self.b_var"
+            self.model.theta_scale.shape
+        ), "true_values must have same dimensions as self.theta_scale"
         assert np.all(
-            true_values.shape == self.model.b_var.shape
-        ), "true_values must have same dimensions as self.b_var"
+            true_values.shape == self.model.theta_scale.shape
+        ), "true_values must have same dimensions as self.theta_scale"
 
         return self._plot_coef_vs_ref(
             true_values=true_values,
-            estim_values=self.model.b_var,
+            estim_values=self.model.theta_scale,
             size=size,
             log=log,
             save=save,
@@ -131,7 +132,7 @@ class _EstimatorGLM(_EstimatorBase, metaclass=abc.ABCMeta):
             return_axs=return_axs,
         )
 
-    def plot_deviation_a(self, true_values: np.ndarray, save=None, show=True, return_axs=False):
+    def plot_deviation_location(self, true_values: np.ndarray, save=None, show=True, return_axs=False):
         """
         Plot deviation of estimated coefficients from reference (true) coefficients
         as violin plot for location model.
@@ -144,22 +145,22 @@ class _EstimatorGLM(_EstimatorBase, metaclass=abc.ABCMeta):
         :return: Matplotlib axis objects.
         """
         assert len(true_values.shape) == len(
-            self.model.a_var.shape
-        ), "true_values must have same dimensions as self.a_var"
+            self.model.theta_location.shape
+        ), "true_values must have same dimensions as self.theta_location"
         assert np.all(
-            true_values.shape == self.model.a_var.shape
-        ), "true_values must have same dimensions as self.a_var"
+            true_values.shape == self.model.theta_location.shape
+        ), "true_values must have same dimensions as self.theta_location"
 
         return self._plot_deviation(
             true_values=true_values,
-            estim_values=self.model.a_var,
+            estim_values=self.model.theta_location,
             save=save,
             show=show,
             title="location_model",
             return_axs=return_axs,
         )
 
-    def plot_deviation_b(self, true_values: np.ndarray, save=None, show=True, return_axs=False):
+    def plot_deviation_scale(self, true_values: np.ndarray, save=None, show=True, return_axs=False):
         """
         Plot deviation of estimated coefficients from reference (true) coefficients
         as violin plot for scale model.
@@ -172,15 +173,15 @@ class _EstimatorGLM(_EstimatorBase, metaclass=abc.ABCMeta):
         :return: Matplotlib axis objects.
         """
         assert len(true_values.shape) == len(
-            self.model.b_var.shape
-        ), "true_values must have same dimensions as self.b_var"
+            self.model.theta_scale.shape
+        ), "true_values must have same dimensions as self.theta_scale"
         assert np.all(
-            true_values.shape == self.model.b_var.shape
-        ), "true_values must have same dimensions as self.b_var"
+            true_values.shape == self.model.theta_scale.shape
+        ), "true_values must have same dimensions as self.theta_scale"
 
         return self._plot_deviation(
             true_values=true_values,
-            estim_values=self.model.b_var,
+            estim_values=self.model.theta_scale,
             save=save,
             show=show,
             title="scale_model",

--- a/batchglm/models/base_glm/input.py
+++ b/batchglm/models/base_glm/input.py
@@ -3,6 +3,7 @@ try:
 except ImportError:
     anndata = None
 from typing import List, Optional, Union
+
 import dask.array
 import numpy as np
 import pandas as pd

--- a/batchglm/models/base_glm/simulator.py
+++ b/batchglm/models/base_glm/simulator.py
@@ -10,9 +10,6 @@ import scipy
 from .external import _SimulatorBase
 from .input import InputDataGLM
 from .model import _ModelGLM
-import logging
-
-logger = logging.getLogger(__name__)
 
 
 def generate_sample_description(
@@ -93,7 +90,7 @@ class _SimulatorGLM(_SimulatorBase, metaclass=abc.ABCMeta):
 
         :param num_conditions: Number of conditions for the design matrix.
         :param num_batches: Number of batches for the design matrix.
-        :param intercept_scale: Whether or not to provide an intercept for the scale model (otherwise just use the location design matrix).
+        :param intercept_scale: Whether to use an intercept for the scale model (use the location design matrix).
         """
         self.sim_design_loc, self.sample_description = generate_sample_description(
             self.nobs, num_conditions=num_conditions, num_batches=num_batches, **kwargs
@@ -189,7 +186,7 @@ class _SimulatorGLM(_SimulatorBase, metaclass=abc.ABCMeta):
         return np.identity(n=self.theta_scale.shape[0])
 
     def param_bounds(self, dtype):
-        """method to be implemented that allows models to constrain certain parameters like means or fitted coefficients"""
+        """method to be implemented for constraining parameters like means or fitted coefficients"""
         pass
 
     def eta_loc_j(self, j) -> np.ndarray:

--- a/batchglm/models/glm_beta/model.py
+++ b/batchglm/models/glm_beta/model.py
@@ -28,7 +28,7 @@ class Model(_ModelGLM, metaclass=abc.ABCMeta):
 
     @property
     def eta_loc(self) -> np.ndarray:
-        eta = np.matmul(self.design_loc, self.a)
+        eta = np.matmul(self.design_loc, self.theta_location_constrained)
         assert self.size_factors is None, "size factors not allowed"
         return eta
 
@@ -36,7 +36,7 @@ class Model(_ModelGLM, metaclass=abc.ABCMeta):
         # Make sure that dimensionality of sliced array is kept:
         if isinstance(j, int) or isinstance(j, np.int32) or isinstance(j, np.int64):
             j = [j]
-        eta = np.matmul(self.design_loc, self.a[:, j])
+        eta = np.matmul(self.design_loc, self.theta_location_constrained[:, j])
         assert self.size_factors is None, "size factors not allowed"
         eta = self.np_clip_param(eta, "eta_loc")
         return eta

--- a/batchglm/models/glm_beta/simulator.py
+++ b/batchglm/models/glm_beta/simulator.py
@@ -25,8 +25,8 @@ class Simulator(_SimulatorGLM, Model):
 
         sf = dtype(pkg_constants.ACCURACY_MARGIN_RELATIVE_TO_LIMIT)
         bounds_min = {
-            "a_var": np.log(zero / (1 - zero)) / sf,
-            "b_var": np.log(zero) / sf,
+            "theta_location": np.log(zero / (1 - zero)) / sf,
+            "theta_scale": np.log(zero) / sf,
             "eta_loc": np.log(zero / (1 - zero)) / sf,
             "eta_scale": np.log(zero) / sf,
             "mean": np.nextafter(0, np.inf, dtype=dtype),
@@ -35,8 +35,8 @@ class Simulator(_SimulatorGLM, Model):
             "log_probs": np.log(zero),
         }
         bounds_max = {
-            "a_var": np.log(one / (1 - one)) / sf,
-            "b_var": np.nextafter(np.log(dmax), -np.inf, dtype=dtype) / sf,
+            "theta_location": np.log(one / (1 - one)) / sf,
+            "theta_scale": np.nextafter(np.log(dmax), -np.inf, dtype=dtype) / sf,
             "eta_loc": np.log(one / (1 - one)) / sf,
             "eta_scale": np.nextafter(np.log(dmax), -np.inf, dtype=dtype) / sf,
             "mean": one,

--- a/batchglm/models/glm_nb/model.py
+++ b/batchglm/models/glm_nb/model.py
@@ -31,7 +31,7 @@ class Model(_ModelGLM, metaclass=abc.ABCMeta):
 
     @property
     def eta_loc(self) -> Union[np.ndarray, dask.array.core.Array]:
-        eta = np.matmul(self.design_loc, self.a)
+        eta = np.matmul(self.design_loc, self.theta_location_constrained)
         if self.size_factors is not None:
             eta += self.size_factors
         eta = self.np_clip_param(eta, "eta_loc")
@@ -41,7 +41,7 @@ class Model(_ModelGLM, metaclass=abc.ABCMeta):
         # Make sure that dimensionality of sliced array is kept:
         if isinstance(j, int) or isinstance(j, np.int32) or isinstance(j, np.int64):
             j = [j]
-        eta = np.matmul(self.design_loc, self.a[:, j])
+        eta = np.matmul(self.design_loc, self.theta_location_constrained[:, j])
         if self.size_factors is not None:
             eta += self.size_factors
         eta = self.np_clip_param(eta, "eta_loc")

--- a/batchglm/models/glm_nb/simulator.py
+++ b/batchglm/models/glm_nb/simulator.py
@@ -2,6 +2,9 @@ import numpy as np
 
 from .external import _SimulatorGLM, pkg_constants
 from .model import Model
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class Simulator(_SimulatorGLM, Model):
@@ -45,8 +48,8 @@ class Simulator(_SimulatorGLM, Model):
 
         sf = dtype(pkg_constants.ACCURACY_MARGIN_RELATIVE_TO_LIMIT)
         bounds_min = {
-            "a_var": np.log(np.nextafter(0, np.inf, dtype=dtype)) / sf,
-            "b_var": np.log(np.nextafter(0, np.inf, dtype=dtype)) / sf,
+            "theta_location": np.log(np.nextafter(0, np.inf, dtype=dtype)) / sf,
+            "theta_scale": np.log(np.nextafter(0, np.inf, dtype=dtype)) / sf,
             "eta_loc": np.log(np.nextafter(0, np.inf, dtype=dtype)) / sf,
             "eta_scale": np.log(np.nextafter(0, np.inf, dtype=dtype)) / sf,
             "loc": np.nextafter(0, np.inf, dtype=dtype),
@@ -55,8 +58,8 @@ class Simulator(_SimulatorGLM, Model):
             "ll": np.log(np.nextafter(0, np.inf, dtype=dtype)),
         }
         bounds_max = {
-            "a_var": np.nextafter(np.log(dmax), -np.inf, dtype=dtype) / sf,
-            "b_var": np.nextafter(np.log(dmax), -np.inf, dtype=dtype) / sf,
+            "theta_location": np.nextafter(np.log(dmax), -np.inf, dtype=dtype) / sf,
+            "theta_scale": np.nextafter(np.log(dmax), -np.inf, dtype=dtype) / sf,
             "eta_loc": np.nextafter(np.log(dmax), -np.inf, dtype=dtype) / sf,
             "eta_scale": np.nextafter(np.log(dmax), -np.inf, dtype=dtype) / sf,
             "loc": np.nextafter(dmax, -np.inf, dtype=dtype) / sf,

--- a/batchglm/models/glm_nb/simulator.py
+++ b/batchglm/models/glm_nb/simulator.py
@@ -2,9 +2,6 @@ import numpy as np
 
 from .external import _SimulatorGLM, pkg_constants
 from .model import Model
-import logging
-
-logger = logging.getLogger(__name__)
 
 
 class Simulator(_SimulatorGLM, Model):

--- a/batchglm/models/glm_norm/model.py
+++ b/batchglm/models/glm_norm/model.py
@@ -61,7 +61,7 @@ class Model(_ModelGLM, metaclass=abc.ABCMeta):
         :rtype: np.ndarray
 
         """
-        eta = np.matmul(self.design_loc, self.a)
+        eta = np.matmul(self.design_loc, self.theta_location_constrained)
         if self.size_factors is not None:
             eta *= np.expand_dims(self.size_factors, axis=1)
         return eta
@@ -77,7 +77,7 @@ class Model(_ModelGLM, metaclass=abc.ABCMeta):
         # Make sure that dimensionality of sliced array is kept:
         if isinstance(j, int) or isinstance(j, np.int32) or isinstance(j, np.int64):
             j = [j]
-        eta = np.matmul(self.design_loc, self.a[:, j])
+        eta = np.matmul(self.design_loc, self.theta_location_constrained[:, j])
         if self.size_factors is not None:
             eta *= np.expand_dims(self.size_factors, axis=1)
         eta = self.np_clip_param(eta, "eta_loc")

--- a/batchglm/models/glm_norm/simulator.py
+++ b/batchglm/models/glm_norm/simulator.py
@@ -2,7 +2,9 @@ import numpy as np
 
 from .external import _SimulatorGLM, pkg_constants
 from .model import Model
+import logging
 
+logger = logging.getLogger(__name__)
 
 class Simulator(_SimulatorGLM, Model):
     """
@@ -21,8 +23,8 @@ class Simulator(_SimulatorGLM, Model):
 
         sf = dtype(pkg_constants.ACCURACY_MARGIN_RELATIVE_TO_LIMIT)
         bounds_min = {
-            "a_var": np.nextafter(-dmax, np.inf, dtype=dtype) / sf,
-            "b_var": np.log(np.nextafter(0, np.inf, dtype=dtype)) / sf,
+            "theta_location": np.nextafter(-dmax, np.inf, dtype=dtype) / sf,
+            "theta_scale": np.log(np.nextafter(0, np.inf, dtype=dtype)) / sf,
             "eta_loc": np.nextafter(-dmax, np.inf, dtype=dtype) / sf,
             "eta_scale": np.log(np.nextafter(0, np.inf, dtype=dtype)) / sf,
             "mean": np.nextafter(-dmax, np.inf, dtype=dtype) / sf,
@@ -31,8 +33,8 @@ class Simulator(_SimulatorGLM, Model):
             "log_probs": np.log(np.nextafter(0, np.inf, dtype=dtype)),
         }
         bounds_max = {
-            "a_var": np.nextafter(dmax, -np.inf, dtype=dtype) / sf,
-            "b_var": np.nextafter(np.log(dmax), -np.inf, dtype=dtype) / sf,
+            "theta_location": np.nextafter(dmax, -np.inf, dtype=dtype) / sf,
+            "theta_scale": np.nextafter(np.log(dmax), -np.inf, dtype=dtype) / sf,
             "eta_loc": np.nextafter(dmax, -np.inf, dtype=dtype) / sf,
             "eta_scale": np.nextafter(np.log(dmax), -np.inf, dtype=dtype) / sf,
             "mean": np.nextafter(dmax, -np.inf, dtype=dtype) / sf,

--- a/batchglm/models/glm_norm/simulator.py
+++ b/batchglm/models/glm_norm/simulator.py
@@ -2,9 +2,7 @@ import numpy as np
 
 from .external import _SimulatorGLM, pkg_constants
 from .model import Model
-import logging
 
-logger = logging.getLogger(__name__)
 
 class Simulator(_SimulatorGLM, Model):
     """

--- a/batchglm/train/numpy/base_glm/estimator.py
+++ b/batchglm/train/numpy/base_glm/estimator.py
@@ -74,9 +74,10 @@ class EstimatorGlm(_EstimatorGLM, metaclass=abc.ABCMeta):
         Convergence decision:
         Location and scale model updates are done in separate iterations and are done with different algorithms.
         Scale model updates are much less frequent (only every update_scale_freq-th iteration) as they are much slower.
-        During a stretch of update_scale_freq number of location model updates between two scale model updates, convergence
-        of the location model is tracked with self.model.converged. This is re-set after a scale model update, as this
-        convergence only holds conditioned on a particular scale model value.
+        During a stretch of update_scale_freq number of location model updates between two scale model updates,
+        convergence of the location model is tracked with self.model.converged.
+        This is re-set after a scale model update,
+        as this convergence only holds conditioned on a particular scale model value.
         Full convergence of a feature wise model is evaluated after each scale model update: If the loss function based
         convergence criterium holds across the cumulative updates of the sequence of location updates and last scale
         model update, the feature is considered converged. For this, the loss value at the last scale model update is
@@ -85,7 +86,8 @@ class EstimatorGlm(_EstimatorGLM, metaclass=abc.ABCMeta):
         :param max_steps:
         :param method_scale:
         :param update_scale_freq: One over minimum frequency of scale model updates per location model update.
-            A scale model update will be run at least every update_scale_freq number of location model update iterations.
+            A scale model update will be run at least
+            every update_scale_freq number of location model update iterations.
         :param ftol_scale:
         :param lr_scale:
         :param max_iter_scale:

--- a/batchglm/train/numpy/base_glm/training_strategies.py
+++ b/batchglm/train/numpy/base_glm/training_strategies.py
@@ -5,8 +5,14 @@ class TrainingStrategies(Enum):
 
     AUTO = None
     DEFAULT = [
-        {"max_steps": 1000, "method_b": "brent", "update_b_freq": 5, "ftol_b": 1e-6, "max_iter_b": 1000},
+        {
+            "max_steps": 1000,
+            "method_scale": "brent",
+            "update_scale_freq": 5,
+            "ftol_scale": 1e-6,
+            "max_iter_scale": 1000,
+        },
     ]
     GD = [
-        {"max_steps": 1000, "method_b": "gd", "update_b_freq": 5, "ftol_b": 1e-6, "max_iter_b": 100},
+        {"max_steps": 1000, "method_scale": "gd", "update_scale_freq": 5, "ftol_scale": 1e-6, "max_iter_scale": 100},
     ]

--- a/batchglm/train/numpy/base_glm/vars.py
+++ b/batchglm/train/numpy/base_glm/vars.py
@@ -16,9 +16,9 @@ class ModelVarsGlm:
         Scale model constraints for VGLM fitting
     constraints_loc : Union[np.ndarray, dask.array.core.Array]
         Location model constraints for VGLM fitting
-    a_var : np.ndarray
+    theta_location : np.ndarray
         Location model parameters
-    b_var : np.ndarray
+    theta_scale : np.ndarray
         Scale model parameters
     converged : np.ndarray
         Whether or not given parameters are converged
@@ -45,17 +45,17 @@ class ModelVarsGlm:
 
     def __init__(
         self,
-        init_a: Union[np.ndarray, dask.array.core.Array],
-        init_b: Union[np.ndarray, dask.array.core.Array],
+        init_location: Union[np.ndarray, dask.array.core.Array],
+        init_scale: Union[np.ndarray, dask.array.core.Array],
         constraints_loc: Union[np.ndarray, dask.array.core.Array],
         constraints_scale: Union[np.ndarray, dask.array.core.Array],
         chunk_size_genes: int,
         dtype: str,
     ):
         """
-        :param init_a:
+        :param init_location:
             Initialisation for all parameters of mean model. (mean model size x features)
-        :param init_b:
+        :param init_scale:
             Initialisation for all parameters of dispersion model. (dispersion model size x features)
         :param constraints_scale:
             Scale model constraints for VGLM fitting
@@ -69,27 +69,27 @@ class ModelVarsGlm:
         self.constraints_loc = np.asarray(constraints_loc, dtype)
         self.constraints_scale = np.asarray(constraints_scale, dtype)
 
-        init_a_clipped = self.np_clip_param(np.asarray(init_a, dtype=dtype), "a_var")
-        init_b_clipped = self.np_clip_param(np.asarray(init_b, dtype=dtype), "b_var")
+        init_location_clipped = self.np_clip_param(np.asarray(init_location, dtype=dtype), "theta_location")
+        init_scale_clipped = self.np_clip_param(np.asarray(init_scale, dtype=dtype), "theta_scale")
         self.params = dask.array.from_array(
             np.concatenate(
                 [
-                    init_a_clipped,
-                    init_b_clipped,
+                    init_location_clipped,
+                    init_scale_clipped,
                 ],
                 axis=0,
             ),
             chunks=(1000, chunk_size_genes),
         )
-        self.npar_a = init_a_clipped.shape[0]
+        self.npar_a = init_location_clipped.shape[0]
 
         # Properties to follow gene-wise convergence.
         self.converged = np.repeat(a=False, repeats=self.params.shape[1])  # Initialise to non-converged.
 
         self.dtype = dtype
         self.n_features = self.params.shape[1]
-        self.idx_train_loc = np.arange(0, init_a.shape[0])
-        self.idx_train_scale = np.arange(init_a.shape[0], init_a.shape[0] + init_b.shape[0])
+        self.idx_train_loc = np.arange(0, init_location.shape[0])
+        self.idx_train_scale = np.arange(init_location.shape[0], init_location.shape[0] + init_scale.shape[0])
 
     @property
     def idx_not_converged(self):
@@ -97,15 +97,15 @@ class ModelVarsGlm:
         return np.where(np.logical_not(self.converged))[0]
 
     @property
-    def a_var(self):
+    def theta_location(self):
         """Location parameters"""
-        a_var = self.params[0 : self.npar_a]
-        return self.np_clip_param(a_var, "a_var")
+        theta_location = self.params[0 : self.npar_a]
+        return self.np_clip_param(theta_location, "theta_location")
 
-    @a_var.setter
-    def a_var(self, value):
+    @theta_location.setter
+    def theta_location(self, value):
         # Threshold new entry:
-        value = self.np_clip_param(value, "a_var")
+        value = self.np_clip_param(value, "theta_location")
         # Write either new dask array or into numpy array:
         if isinstance(self.params, dask.array.core.Array):
             temp = self.params.compute()
@@ -115,15 +115,15 @@ class ModelVarsGlm:
             self.params[0 : self.npar_a] = value
 
     @property
-    def b_var(self):
+    def theta_scale(self):
         """Scale parameters"""
-        b_var = self.params[self.npar_a :]
-        return self.np_clip_param(b_var, "b_var")
+        theta_scale = self.params[self.npar_a :]
+        return self.np_clip_param(theta_scale, "theta_scale")
 
-    @b_var.setter
-    def b_var(self, value):
+    @theta_scale.setter
+    def theta_scale(self, value):
         # Threshold new entry:
-        value = self.np_clip_param(value, "b_var")
+        value = self.np_clip_param(value, "theta_scale")
         # Write either new dask array or into numpy array:
         if isinstance(self.params, dask.array.core.Array):
             temp = self.params.compute()
@@ -132,10 +132,10 @@ class ModelVarsGlm:
         else:
             self.params[self.npar_a :] = value
 
-    def b_var_j_setter(self, value, j):
-        """Setter ofr a specific b_var value."""
+    def theta_scale_j_setter(self, value, j):
+        """Setter ofr a specific theta_scale value."""
         # Threshold new entry:
-        value = self.np_clip_param(value, "b_var")
+        value = self.np_clip_param(value, "theta_scale")
         # Write either new dask array or into numpy array:
         if isinstance(self.params, dask.array.core.Array):
             temp = self.params.compute()

--- a/batchglm/train/numpy/glm_nb/estimator.py
+++ b/batchglm/train/numpy/glm_nb/estimator.py
@@ -22,8 +22,8 @@ class Estimator(EstimatorGlm):
     def __init__(
         self,
         input_data: InputDataGLM,
-        init_a: Union[np.ndarray, str] = "AUTO",
-        init_b: Union[np.ndarray, str] = "AUTO",
+        init_location: Union[np.ndarray, str] = "AUTO",
+        init_scale: Union[np.ndarray, str] = "AUTO",
         batch_size: Optional[Union[Tuple[int, int], int]] = None,
         quick_scale: bool = False,
         dtype="float64",
@@ -34,7 +34,7 @@ class Estimator(EstimatorGlm):
 
         :param input_data: InputDataGLM
             The input data
-        :param init_a: (Optional)
+        :param init_location: (Optional)
             Low-level initial values for a. Can be:
 
             - str:
@@ -44,7 +44,7 @@ class Estimator(EstimatorGlm):
                 * "init_model": initialize with another model (see `ìnit_model` parameter)
                 * "closed_form": try to initialize with closed form
             - np.ndarray: direct initialization of 'a'
-        :param init_b: (Optional)
+        :param init_scale: (Optional)
             Low-level initial values for b. Can be:
 
             - str:
@@ -59,8 +59,8 @@ class Estimator(EstimatorGlm):
             Useful in scenarios where fitting the exact `scale` is not absolutely necessary.
         :param dtype: Numerical precision.
         """
-        init_a, init_b, train_loc, train_scale = init_par(
-            input_data=input_data, init_a=init_a, init_b=init_b, init_model=None
+        init_location, init_scale, train_loc, train_scale = init_par(
+            input_data=input_data, init_location=init_location, init_scale=init_scale, init_model=None
         )
         self._train_loc = train_loc
         self._train_scale = train_scale
@@ -68,12 +68,12 @@ class Estimator(EstimatorGlm):
             self._train_scale = False
         sys.stdout.write("training location model: %s\n" % str(self._train_loc))
         sys.stdout.write("training scale model: %s\n" % str(self._train_scale))
-        init_a = init_a.astype(dtype)
-        init_b = init_b.astype(dtype)
+        init_location = init_location.astype(dtype)
+        init_scale = init_scale.astype(dtype)
 
         self.model_vars = ModelVars(
-            init_a=init_a,
-            init_b=init_b,
+            init_location=init_location,
+            init_scale=init_scale,
             constraints_loc=input_data.constraints_loc,
             constraints_scale=input_data.constraints_scale,
             chunk_size_genes=input_data.chunk_size_genes,
@@ -83,7 +83,7 @@ class Estimator(EstimatorGlm):
             input_data=input_data,
             model_vars=self.model_vars,
             compute_mu=self._train_loc,
-            compute_r=not self._train_scale
+            compute_r=not self._train_scale,
         )
         super(Estimator, self).__init__(input_data=input_data, model=model, dtype=dtype)
 

--- a/batchglm/train/numpy/glm_nb/processModel.py
+++ b/batchglm/train/numpy/glm_nb/processModel.py
@@ -12,8 +12,8 @@ class ProcessModel(ProcessModelGlm):
 
         sf = dtype(pkg_constants.ACCURACY_MARGIN_RELATIVE_TO_LIMIT)
         bounds_min = {
-            "a_var": np.log(np.nextafter(0, np.inf, dtype=dtype)) / sf,
-            "b_var": np.log(np.nextafter(0, np.inf, dtype=dtype)) / sf,
+            "theta_location": np.log(np.nextafter(0, np.inf, dtype=dtype)) / sf,
+            "theta_scale": np.log(np.nextafter(0, np.inf, dtype=dtype)) / sf,
             "eta_loc": np.log(np.nextafter(0, np.inf, dtype=dtype)) / sf,
             "eta_scale": np.log(np.nextafter(0, np.inf, dtype=dtype)) / sf,
             "loc": np.nextafter(0, np.inf, dtype=dtype),
@@ -22,8 +22,8 @@ class ProcessModel(ProcessModelGlm):
             "ll": np.log(np.nextafter(0, np.inf, dtype=dtype)),
         }
         bounds_max = {
-            "a_var": np.nextafter(np.log(dmax), -np.inf, dtype=dtype) / sf,
-            "b_var": np.nextafter(np.log(dmax), -np.inf, dtype=dtype) / sf,
+            "theta_location": np.nextafter(np.log(dmax), -np.inf, dtype=dtype) / sf,
+            "theta_scale": np.nextafter(np.log(dmax), -np.inf, dtype=dtype) / sf,
             "eta_loc": np.nextafter(np.log(dmax), -np.inf, dtype=dtype) / sf,
             "eta_scale": np.nextafter(np.log(dmax), -np.inf, dtype=dtype) / sf,
             "loc": np.nextafter(dmax, -np.inf, dtype=dtype) / sf,

--- a/tests/test_acc_glm_all_numpy.py
+++ b/tests/test_acc_glm_all_numpy.py
@@ -48,7 +48,9 @@ class _TestAccuracyGlmAllEstim:
                 chunk_size_genes=2,
             )
 
-        self.estimator = Estimator(input_data=input_data, quick_scale=quick_scale, init_a=init_mode, init_b=init_mode)
+        self.estimator = Estimator(
+            input_data=input_data, quick_scale=quick_scale, init_location=init_mode, init_scale=init_mode
+        )
         self.sim = simulator
 
     def estimate(self):
@@ -63,8 +65,12 @@ class _TestAccuracyGlmAllEstim:
 
         success = True
         if train_loc:
-            mean_rel_dev_a = np.mean((self.estimator.model.a_var - self.sim.a_var) / self.sim.a_var)
-            std_rel_dev_a = np.std((self.estimator.model.a_var - self.sim.a_var) / self.sim.a_var)
+            mean_rel_dev_a = np.mean(
+                (self.estimator.model.theta_location - self.sim.theta_location) / self.sim.theta_location
+            )
+            std_rel_dev_a = np.std(
+                (self.estimator.model.theta_location - self.sim.theta_location) / self.sim.theta_location
+            )
 
             logging.getLogger("batchglm").info("mean_rel_dev_a %f" % mean_rel_dev_a)
             logging.getLogger("batchglm").info("std_rel_dev_a %f" % std_rel_dev_a)
@@ -72,8 +78,8 @@ class _TestAccuracyGlmAllEstim:
             if np.abs(mean_rel_dev_a) > threshold_dev_a or std_rel_dev_a > threshold_std_a:
                 success = False
         if train_scale:
-            mean_rel_dev_b = np.mean((self.estimator.model.b_var - self.sim.b_var) / self.sim.b_var)
-            std_rel_dev_b = np.std((self.estimator.model.b_var - self.sim.b_var) / self.sim.b_var)
+            mean_rel_dev_b = np.mean((self.estimator.model.theta_scale - self.sim.theta_scale) / self.sim.theta_scale)
+            std_rel_dev_b = np.std((self.estimator.model.theta_scale - self.sim.theta_scale) / self.sim.theta_scale)
 
             logging.getLogger("batchglm").info("mean_rel_dev_b %f" % mean_rel_dev_b)
             logging.getLogger("batchglm").info("std_rel_dev_b %f" % std_rel_dev_b)
@@ -94,14 +100,14 @@ class _TestAccuracyGlmAll(unittest.TestCase):
     for each training graph. The training graphs tested are as follows:
 
      - full data model
-        - train a and b model: test_full_global_a_and_b()
-        - train a model only: test_full_global_a_only()
-        - train b model only: test_full_global_b_only()
+        - train a and b model: test_full_global_location_and_scale()
+        - train a model only: test_full_global_location_only()
+        - train b model only: test_full_global_scale_only()
 
     - batched data model
-        - train a and b model: test_batched_global_a_and_b()
-        - train a model only: test_batched_global_a_only()
-        - train b model only: test_batched_global_b_only()
+        - train a and b model: test_batched_global_location_and_scale()
+        - train a model only: test_batched_global_location_only()
+        - train b model only: test_batched_global_scale_only()
 
     The unit tests throw an assertion error if the required accurcy is
     not met. Accuracy thresholds are fairly lenient so that unit_tests
@@ -249,33 +255,33 @@ class _TestAccuracyGlmAll(unittest.TestCase):
 
         return True
 
-    def _test_full_a_and_b(self, sparse):
+    def _test_full_location_and_scale(self, sparse):
         return self.basic_test(batched=False, train_loc=True, train_scale=True, sparse=sparse)
 
-    def _test_full_a_only(self, sparse):
+    def _test_full_location_only(self, sparse):
         return self.basic_test(batched=False, train_loc=True, train_scale=False, sparse=sparse)
 
-    def _test_full_b_only(self, sparse):
+    def _test_full_scale_only(self, sparse):
         return self.basic_test(batched=False, train_loc=False, train_scale=True, sparse=sparse)
 
-    def _test_batched_a_and_b(self, sparse):
+    def _test_batched_location_and_scale(self, sparse):
         return self.basic_test(batched=True, train_loc=True, train_scale=True, sparse=sparse)
 
-    def _test_batched_a_only(self, sparse):
+    def _test_batched_location_only(self, sparse):
         return self.basic_test(batched=True, train_loc=True, train_scale=False, sparse=sparse)
 
-    def _test_batched_b_only(self, sparse):
+    def _test_batched_scale_only(self, sparse):
         return self.basic_test(batched=True, train_loc=False, train_scale=True, sparse=sparse)
 
     def _test_full(self, sparse):
-        self._test_full_a_and_b(sparse=sparse)
-        self._test_full_a_only(sparse=sparse)
-        self._test_full_b_only(sparse=sparse)
+        self._test_full_location_and_scale(sparse=sparse)
+        self._test_full_location_only(sparse=sparse)
+        self._test_full_scale_only(sparse=sparse)
 
     def _test_batched(self, sparse):
-        self._test_batched_a_and_b(sparse=sparse)
-        self._test_batched_a_only(sparse=sparse)
-        self._test_batched_b_only(sparse=sparse)
+        self._test_batched_location_and_scale(sparse=sparse)
+        self._test_batched_location_only(sparse=sparse)
+        self._test_batched_scale_only(sparse=sparse)
 
 
 class TestAccuracyGlmNb(_TestAccuracyGlmAll, unittest.TestCase):

--- a/tests/test_extreme_values_glm_all.py
+++ b/tests/test_extreme_values_glm_all.py
@@ -37,37 +37,37 @@ class _TestAccuracyXtremeAll(_TestGraphGlmAll):
         )
         self.sim1.input_data = input_data
 
-    def _test_low_values_a_and_b(self):
+    def _test_low_values_location_and_scale(self):
         self._modify_sim(idx=0, val=0.0)
         return self.basic_test(batched=False, train_loc=True, train_scale=True, sparse=False)
 
-    def _test_low_values_a_only(self):
+    def _test_low_values_location_only(self):
         self._modify_sim(idx=0, val=0.0)
         return self.basic_test(batched=False, train_loc=True, train_scale=True, sparse=False)
 
-    def _test_low_values_b_only(self):
+    def _test_low_values_scale_only(self):
         self._modify_sim(idx=0, val=0.0)
         return self.basic_test(batched=False, train_loc=True, train_scale=True, sparse=False)
 
-    def _test_zero_variance_a_and_b(self):
+    def _test_zero_variance_location_and_scale(self):
         self._modify_sim(idx=0, val=5.0)
         return self.basic_test(batched=False, train_loc=True, train_scale=True, sparse=False)
 
-    def _test_zero_variance_a_only(self):
+    def _test_zero_variance_location_only(self):
         self._modify_sim(idx=0, val=5.0)
         return self.basic_test(batched=False, train_loc=True, train_scale=True, sparse=False)
 
-    def _test_zero_variance_b_only(self):
+    def _test_zero_variance_scale_only(self):
         self._modify_sim(idx=0, val=5.0)
         return self.basic_test(batched=False, train_loc=True, train_scale=True, sparse=False)
 
     def _test_all(self):
-        self._test_low_values_a_and_b()
-        self._test_low_values_a_only()
-        self._test_low_values_b_only()
-        self._test_zero_variance_a_and_b()
-        self._test_zero_variance_a_only()
-        self._test_zero_variance_b_only()
+        self._test_low_values_location_and_scale()
+        self._test_low_values_location_only()
+        self._test_low_values_scale_only()
+        self._test_zero_variance_location_and_scale()
+        self._test_zero_variance_location_only()
+        self._test_zero_variance_scale_only()
 
 
 class TestAccuracyXtremeNb(_TestAccuracyXtremeAll, unittest.TestCase):

--- a/tests/test_graph_glm_all.py
+++ b/tests/test_graph_glm_all.py
@@ -91,14 +91,14 @@ class _TestGraphGlmAll:
     to accuracy outliers. The training graphs covered are:
 
      - full data model
-        - train a and b model: test_full_global_a_and_b()
-        - train a model only: test_full_global_a_only()
-        - train b model only: test_full_global_b_only()
+        - train a and b model: test_full_global_location_and_scale()
+        - train a model only: test_full_global_location_only()
+        - train b model only: test_full_global_scale_only()
 
     - batched data model
-        - train a and b model: test_batched_global_a_and_b()
-        - train a model only: test_batched_global_a_only()
-        - train b model only: test_batched_global_b_only()
+        - train a and b model: test_batched_global_location_and_scale()
+        - train a model only: test_batched_global_location_only()
+        - train b model only: test_batched_global_scale_only()
     """
 
     noise_model: str
@@ -162,35 +162,35 @@ class _TestGraphGlmAll:
                 batched=batched, train_loc=train_loc, train_scale=train_scale, algo=algo, sparse=sparse
             )
 
-    def _test_full_a_and_b(self, sparse):
+    def _test_full_location_and_scale(self, sparse):
         return self.basic_test(batched=False, train_loc=True, train_scale=True, sparse=sparse)
 
-    def _test_full_a_only(self, sparse):
+    def _test_full_location_only(self, sparse):
         return self.basic_test(batched=False, train_loc=True, train_scale=False, sparse=sparse)
 
-    def _test_full_b_only(self, sparse):
+    def _test_full_scale_only(self, sparse):
         return self.basic_test(batched=False, train_loc=False, train_scale=True, sparse=sparse)
 
-    def _test_batched_a_and_b(self, sparse):
+    def _test_batched_location_and_scale(self, sparse):
         return self.basic_test(batched=True, train_loc=True, train_scale=True, sparse=sparse)
 
-    def _test_batched_a_only(self, sparse):
+    def _test_batched_location_only(self, sparse):
         return self.basic_test(batched=True, train_loc=True, train_scale=False, sparse=sparse)
 
-    def _test_batched_b_only(self, sparse):
+    def _test_batched_scale_only(self, sparse):
         return self.basic_test(batched=True, train_loc=False, train_scale=True, sparse=sparse)
 
     def _test_full(self, sparse):
         self.simulate()
-        self._test_full_a_and_b(sparse=sparse)
-        self._test_full_a_only(sparse=sparse)
-        self._test_full_b_only(sparse=sparse)
+        self._test_full_location_and_scale(sparse=sparse)
+        self._test_full_location_only(sparse=sparse)
+        self._test_full_scale_only(sparse=sparse)
 
     def _test_batched(self, sparse):
         self.simulate()
-        self._test_batched_a_and_b(sparse=sparse)
-        self._test_batched_a_only(sparse=sparse)
-        self._test_batched_b_only(sparse=sparse)
+        self._test_batched_location_and_scale(sparse=sparse)
+        self._test_batched_location_only(sparse=sparse)
+        self._test_batched_scale_only(sparse=sparse)
 
 
 class TestGraphGlmNb(_TestGraphGlmAll, unittest.TestCase):


### PR DESCRIPTION
This PR tries to make the code more readable by lining/unifying our use of terminology to center around `location` and `scale`.  This PR also runs `black` which was apparently not running on #124.